### PR TITLE
Attempt to fix port leak, also fixed clean up of sockets.

### DIFF
--- a/src/lhttpc_lb.erl
+++ b/src/lhttpc_lb.erl
@@ -156,7 +156,7 @@ code_change(_OldVsn, State, _Extra) ->
 terminate(_Reason, #state{host=H, port=P, ssl=Ssl, free=Free, clients=Tid}) ->
     ets:delete(Tid),
     ets:delete(?MODULE,{H,P,Ssl}),
-    [lhttpc_sock:close(Socket,Ssl) || Socket <- Free],
+    [lhttpc_sock:close(Socket,Ssl) || {Socket, _TimerRef} <- Free],
     ok.
 
 %%%%%%%%%%%%%%%


### PR DESCRIPTION
There is a possibility of port leak when processes are killed using exit/2 BIF when they are connecting/closing sockets, executing in prim_inet module.
Also fixed the format of remaining free sockets in terminate/2.
