### PR TITLE
Fix for option type

### DIFF
--- a/include/lhttpc_types.hrl
+++ b/include/lhttpc_types.hrl
@@ -30,7 +30,7 @@
 -type socket() :: _.
 
 -type option() ::
-        {connect_option, list()} |
+        {connect_options, list()} |
         {connect_timeout, timeout()} |
         {connection_timeout, non_neg_integer() | infinity} |
         {max_connections, non_neg_integer()} |


### PR DESCRIPTION
This makes it easier to run dialyzer on a project that is using lhttpc.
