### PR TITLE
Move now() usage to make_ref()

### DIFF
--- a/src/lhttpc.erl
+++ b/src/lhttpc.erl
@@ -334,7 +334,7 @@ request(URL, Method, Hdrs, Body, Timeout, Options) ->
     headers(), iolist(), timeout(), [option()]) -> result().
 request(Host, Port, Ssl, Path, Method, Hdrs, Body, Timeout, Options) ->
     ok = verify_options(Options),
-    ReqId = now(),
+    ReqId = make_ref(),
     case proplists:is_defined(stream_to, Options) of
         true ->
             StreamTo = proplists:get_value(stream_to, Options),


### PR DESCRIPTION
The purpose of 'now()' was to uniquely mark message -- there should be
no downside to instead using make_ref(), making it fully compatible
backwards and forwards as a fix.